### PR TITLE
Graph Names and Sample Means Bin Size

### DIFF
--- a/src/central_limit_theorem/CentralLimitGraph.jsx
+++ b/src/central_limit_theorem/CentralLimitGraph.jsx
@@ -203,7 +203,7 @@ export class CentralLimitGraph extends Component {
 
         let sampleMeansGraphData = createScatterPlotHistogram(
             sampleMeans.slice(0, 1),
-            NO_OF_BINS,
+            NO_OF_BINS * 4,
             MIN_BIN,
             MAX_BIN);
 
@@ -244,7 +244,7 @@ export class CentralLimitGraph extends Component {
         let currentSampleMeans = this.state.sampleMeans.slice(0, idx);
         let currentSampleMeansData = createScatterPlotHistogram(
             currentSampleMeans,
-            NO_OF_BINS,
+            NO_OF_BINS * 4,
             MIN_BIN,
             MAX_BIN);
         let samplesGraphData = createScatterPlotHistogram(
@@ -335,7 +335,8 @@ export class CentralLimitGraph extends Component {
                             handleResetSamples={
                                 this.handleResetSamples}/>
                     </div>
-                    <div className='col-8' style={{maxHeight: '320px'}}>
+                    <div className='col-8 sticky-top'
+                        style={{maxHeight: '320px'}}>
                         <PopulationGraph
                             populationGraphData={
                                 this.state.populationGraphData}

--- a/src/central_limit_theorem/PopulationGraph.jsx
+++ b/src/central_limit_theorem/PopulationGraph.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     VictoryChart, VictoryTheme, VictoryBar,
-    VictoryScatter, VictoryAxis } from 'victory';
+    VictoryScatter, VictoryAxis, VictoryLegend } from 'victory';
 import * as math from 'mathjs';
 math.config({matrix: 'Array'});
 import { getHistogramMaxima } from '../utils.js';
@@ -24,6 +24,11 @@ export const PopulationGraph  = (
             domain={{x: [MIN_BIN, MAX_BIN]}}>
             <VictoryAxis
                 tickValues={math.range(MIN_BIN, MAX_BIN, true)} />
+            <VictoryLegend
+                title='Population and Current Sample'
+                style={{ title: { fontSize: '28px' },
+                    data: { display: 'none' },
+                    labels: { display: 'none' }}}/>
             {populationGraphData &&
                 <VictoryBar data={populationGraphData}
                     alignment='start'

--- a/src/central_limit_theorem/SampleMeansGraph.jsx
+++ b/src/central_limit_theorem/SampleMeansGraph.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     VictoryChart, VictoryTheme, VictoryAxis,
-    VictoryScatter, VictoryLabel } from 'victory';
+    VictoryScatter, VictoryLabel, VictoryLegend } from 'victory';
 import * as math from 'mathjs';
 math.config({matrix: 'Array'});
 import { MIN_BIN, MAX_BIN } from './CentralLimitGraph';
@@ -22,7 +22,7 @@ export const SampleMeansGraph = ({
 
         sampleMean = currSM[2];
         sampleMeanVector = [{
-            x: currSM[0] + 0.5,
+            x: currSM[0],
             y: currSM[1],
         }];
     }
@@ -35,9 +35,14 @@ export const SampleMeansGraph = ({
             domain={{x: [MIN_BIN, MAX_BIN], y: range}}>
             <VictoryAxis
                 tickValues={math.range(MIN_BIN, MAX_BIN, true)} />
+            <VictoryLegend
+                title='Distribution of Sample Means'
+                style={{ title: { fontSize: '28px' },
+                    data: { display: 'none' },
+                    labels: { display: 'none' }}}/>
             {sampleMeansGraphData &&
                 <VictoryScatter data={sampleMeansGraphData}
-                    x={(datum) => datum[0] + 0.5}
+                    x={0}
                     y={1}
                     style={{ data: { fill: BAR_FILL, stroke: BAR_BORDER,
                         strokeWidth: '2px'} }}/>


### PR DESCRIPTION
This commit makes three minor changes:
- Adds title to each graph
- Makes the graph box sticky
- Increases the number of bins for the sample means graph to better
illustrate a normal distribution.