### PR TITLE
COJ-304 Add visual distinction for top right graph

### DIFF
--- a/src/clt_least_squares/CLTLeastSquares.jsx
+++ b/src/clt_least_squares/CLTLeastSquares.jsx
@@ -258,7 +258,20 @@ export class CLTLeastSquares extends Component {
                         </div>
                     </div>
                     <div className={'col-4'}>
-                        <div className={'cls-graph-container'}>
+                        <div className={`cls-graph-container
+                            cls-population-graph-container`}>
+                            <div className={'cls-arrow cls-arrow-left'}>
+                                <div className={'arrow-point'}></div>
+                                <div className={'arrow-shaft'}></div>
+                            </div>
+                            <div className={'cls-arrow cls-arrow-bottom-left'}>
+                                <div className={'arrow-point'}></div>
+                                <div className={'arrow-shaft'}></div>
+                            </div>
+                            <div className={'cls-arrow cls-arrow-bottom'}>
+                                <div className={'arrow-point'}></div>
+                                <div className={'arrow-shaft'}></div>
+                            </div>
                             <h2>Sample Data</h2>
                             <div>
                                 <PopulationGraph

--- a/src/scss/components/clt_least_squares/clt-least-squares.scss
+++ b/src/scss/components/clt_least_squares/clt-least-squares.scss
@@ -23,3 +23,55 @@
 .clt-ols-active-values {
     margin-bottom: 1em;
 }
+
+$highlight-color: #347EA8;
+
+.cls-arrow {
+    width: 50px;
+    height: 25px;
+    display: flex;
+
+    .arrow-point {
+        width: 0;
+        height: 0;
+        border-top: 12px solid transparent;
+        border-right: 15px solid $highlight-color;
+        border-bottom: 12px solid transparent;
+    }
+
+    .arrow-shaft {
+        width: 70%;
+        background-color: $highlight-color;
+        margin: 5px 0 5px 0;
+    }
+}
+
+.cls-population-graph-container {
+    border: solid 4px $highlight-color;
+    // The no-op scale is needed to force the arrows
+    // to position relative to the container
+    transform: scale(1);
+
+    .cls-arrow-left {
+        position: absolute;
+        top: calc(50% - 12px);
+        left: -40px;
+        z-index: 10000;
+    }
+
+    .cls-arrow-bottom-left {
+        position: absolute;
+        top: calc(100% - 12px);
+        left: -25px;
+        z-index: 10000;
+        transform: rotate(-45deg);
+    }
+
+    .cls-arrow-bottom {
+        position: absolute;
+        top: calc(100% + 5px);
+        left: calc(50% - 12px);
+        z-index: 10000;
+        transform: rotate(-90deg);
+    }
+}


### PR DESCRIPTION
This is a straight css implementation to add arrows to the edges of the population graph.

![image](https://user-images.githubusercontent.com/6710696/57317365-e5560980-70c5-11e9-9c5e-11bfbdcf92b0.png)
