### PR TITLE
COJ-345 Population line parameters bug

### DIFF
--- a/src/clt_least_squares/CLTLeastSquares.jsx
+++ b/src/clt_least_squares/CLTLeastSquares.jsx
@@ -318,8 +318,8 @@ export class CLTLeastSquares extends Component {
                                     population={this.state.population}
                                     populationRegression={
                                         this.state.populationRegression}
-                                    slope={this.state.alpha}
-                                    intercept={this.state.beta}
+                                    slope={this.state.beta}
+                                    intercept={this.state.alpha}
                                     sampleIdx={this.state.sampleIdx}/>
                             </div>
                         </div>


### PR DESCRIPTION
This commit fixes a bug such that the B_0 and B_1 values were swapped
when drawing the population regression line.