### PR TITLE
Tooltip refactor

### DIFF
--- a/src/linear_regression_model/TaxRateSlider.jsx
+++ b/src/linear_regression_model/TaxRateSlider.jsx
@@ -4,6 +4,7 @@ import Rheostat from 'rheostat';
 import { NumericField } from '../utility_components/NumericField';
 import { InlineMath } from 'react-katex';
 import ReactTooltip from 'react-tooltip';
+import { Tooltip } from '../utility_components/Tooltip';
 
 const getTaxRateFromIdx = (val) => {
     let taxRateIdx = Math.floor((val)/ 20);
@@ -78,23 +79,18 @@ export const TaxRateSlider = ({taxRateIdx,
                                     The number entered is outside the
                                     range of the dataset.
                                 </div>
-                                <span className="help-tooltip"
-                                    tabIndex="0"
-                                    data-tip
-                                    data-for="i-tt">
+                                <Tooltip tooltip={
                                     <sup>
                                         <i className="fas fa-question-circle">
                                         </i>
                                     </sup>
-                                </span>
-                                <ReactTooltip id="i-tt" event="focus"
-                                    eventOff="blur">
+                                }>
                                     <span>Represents a single smoker in the tax
                                         data, used to index into&nbsp;
                                     <InlineMath>
                                         {String.raw`y`}
                                     </InlineMath></span>
-                                </ReactTooltip>
+                                </Tooltip>
                             </label>
                             <div id={'observation-slider'}
                                 style={{ height: '50px',

--- a/src/linear_regression_model/TaxRateSlider.jsx
+++ b/src/linear_regression_model/TaxRateSlider.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Rheostat from 'rheostat';
 import { NumericField } from '../utility_components/NumericField';
 import { InlineMath } from 'react-katex';
-import ReactTooltip from 'react-tooltip';
 import { Tooltip } from '../utility_components/Tooltip';
 
 const getTaxRateFromIdx = (val) => {
@@ -83,8 +82,7 @@ export const TaxRateSlider = ({taxRateIdx,
                                     <sup>
                                         <i className="fas fa-question-circle">
                                         </i>
-                                    </sup>
-                                }>
+                                    </sup>}>
                                     <span>Represents a single smoker in the tax
                                         data, used to index into&nbsp;
                                     <InlineMath>
@@ -116,40 +114,28 @@ export const TaxRateSlider = ({taxRateIdx,
                                 {String.raw`x_{${taxRateIdx + 1}} = ${
                                     getTaxRateFromIdx(taxRateIdx)}`}
                             </InlineMath>
-                            <span className="help-tooltip"
-                                tabIndex="0"
-                                data-tip
-                                data-for="x-tt">
+                            <Tooltip tooltip={
                                 <sup>
                                     <i className="fas fa-question-circle">
                                     </i>
-                                </sup>
-                            </span>
-                            <ReactTooltip id="x-tt" event="focus"
-                                eventOff="blur">
+                                </sup>}>
                                 <span>Represents the tax rate a smoker is
                                     subject to</span>
-                            </ReactTooltip>
+                            </Tooltip>
                         </div>
                         <div className={isStateA ? ('col-6') : ('col-12') +
                                 ' tax-rate-datum'}>
                             <InlineMath>
                                 {String.raw`y_{${taxRateIdx + 1}} = ${y_i}`}
                             </InlineMath>
-                            <span className="help-tooltip"
-                                tabIndex="0"
-                                data-tip
-                                data-for="y-tt">
+                            <Tooltip tooltip={
                                 <sup>
                                     <i className="fas fa-question-circle">
                                     </i>
-                                </sup>
-                            </span>
-                            <ReactTooltip id="y-tt" event="focus"
-                                eventOff="blur">
+                                </sup>}>
                                 <span>Represents the number of cigarettes per
                                     day a given person smokes</span>
-                            </ReactTooltip>
+                            </Tooltip>
                         </div>
                     </div>
                     <div className="form-row tax-rate-data-row">
@@ -159,19 +145,13 @@ export const TaxRateSlider = ({taxRateIdx,
                                 {/* eslint-disable-next-line */}
                                 {String.raw`\mu_Y = 29 - 2 \cdot ${getTaxRateFromIdx(taxRateIdx)} = ${mean}`}
                             </InlineMath>
-                            <span className="help-tooltip"
-                                tabIndex="0"
-                                data-tip
-                                data-for="mu-tt">
+                            <Tooltip tooltip={
                                 <sup>
                                     <i className="fas fa-question-circle">
                                     </i>
-                                </sup>
-                            </span>
-                            <ReactTooltip id="mu-tt" event="focus"
-                                eventOff="blur">
+                                </sup>}>
                                 <span>Mean of all smokers</span>
-                            </ReactTooltip>
+                            </Tooltip>
                         </div>
                         <div className={isStateA ? ('col-6') : ('col-12') +
                                 ' tax-rate-datum'}>
@@ -179,19 +159,13 @@ export const TaxRateSlider = ({taxRateIdx,
                                 {/* eslint-disable-next-line */}
                                 {String.raw`\varepsilon_{${taxRateIdx + 1}} = ${epsilon}`}
                             </InlineMath>
-                            <span className="help-tooltip"
-                                tabIndex="0"
-                                data-tip
-                                data-for="epslion-tt">
+                            <Tooltip tooltip={
                                 <sup>
                                     <i className="fas fa-question-circle">
                                     </i>
-                                </sup>
-                            </span>
-                            <ReactTooltip id="epslion-tt" event="focus"
-                                eventOff="blur">
+                                </sup>}>
                                 <span>Deviation from the mean</span>
-                            </ReactTooltip>
+                            </Tooltip>
                         </div>
                     </div>
                 </div>

--- a/src/scss/base/tooltip.scss
+++ b/src/scss/base/tooltip.scss
@@ -1,3 +1,53 @@
+// Library tooltip styles
 .__react_component_tooltip {
     z-index: 100000;
+}
+
+// Custom tooltip styles
+%button-reset {
+    padding: 0;
+    border: none;
+    font: inherit;
+    color: inherit;
+    background-color: transparent;
+    cursor: pointer;
+}
+
+.tooltip-trigger {
+    @extend %button-reset;
+    margin-left: 0.25em;
+    &:focus {
+        outline: none;
+        color: #0D993F;
+    }
+}
+
+.tooltip-box {
+    position: absolute;
+    display: inline-block;
+    top: -3em;
+    padding: 0.5em;
+    margin-bottom: 0px !important;
+    margin-right: -100%;
+    z-index: 10000;
+
+    border-radius: 5px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 0px;
+    color: #FFFFFF;
+    background-color: rgba(0, 0, 0, 0.8);
+
+    &:before {
+        content: "";
+        position: absolute;
+        right: 100%;
+        bottom: -7px;
+        left: 0px;
+        border-top: 7px solid transparent;
+        border-right: 14px solid rgba(0, 0, 0, 0.8);
+        border-bottom: 7px solid transparent;
+        transform: rotate(180deg);
+    }
 }

--- a/src/utility_components/Tooltip.jsx
+++ b/src/utility_components/Tooltip.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
@@ -16,7 +15,7 @@ export class Tooltip extends Component {
 
         this.initialState = {
             showTooltip: false,
-        }
+        };
         this.state = this.initialState;
     }
     onButtonClick(e) {
@@ -24,8 +23,8 @@ export class Tooltip extends Component {
         this.setState((state) => {
             return {
                 showTooltip: !state.showTooltip,
-            }
-        })
+            };
+        });
     }
     onButtonBlur(e) {
         e.preventDefault();
@@ -60,4 +59,5 @@ export class Tooltip extends Component {
 
 Tooltip.propTypes = {
     tooltip: PropTypes.object,
+    children: PropTypes.object,
 };

--- a/src/utility_components/Tooltip.jsx
+++ b/src/utility_components/Tooltip.jsx
@@ -1,0 +1,63 @@
+/* eslint-disable */
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+// Use a counter to set unique-ish ids
+let componentIdCounter = 0;
+
+export class Tooltip extends Component {
+    constructor(props) {
+        super(props);
+
+        this.onButtonClick = this.onButtonClick.bind(this);
+        this.onButtonBlur = this.onButtonBlur.bind(this);
+
+        this.componentId = 'tooltip-' + componentIdCounter++;
+
+        this.initialState = {
+            showTooltip: false,
+        }
+        this.state = this.initialState;
+    }
+    onButtonClick(e) {
+        e.preventDefault();
+        this.setState((state) => {
+            return {
+                showTooltip: !state.showTooltip,
+            }
+        })
+    }
+    onButtonBlur(e) {
+        e.preventDefault();
+        this.setState({
+            showTooltip: false,
+        });
+    }
+    render() {
+        return (
+            <>
+                <button
+                    className={'tooltip-trigger'}
+                    type='button'
+                    onClick={this.onButtonClick}
+                    onBlur={this.onButtonBlur}
+                    aria-describedby={this.componentId}>
+                    {this.props.tooltip}
+                    <span className="sr-only">toggle tooltip</span>
+                </button>
+                { this.state.showTooltip &&
+                    <div role="tooltip"
+                        id={this.componentId}
+                        className={'tooltip-box'}>
+                        { this.props.children }
+                    </div>
+                }
+            </>
+        );
+    }
+}
+
+
+Tooltip.propTypes = {
+    tooltip: PropTypes.object,
+};


### PR DESCRIPTION
This PR implements a new tooltip component, to address the broken tooltips on the Linear Regression Model page.

It only replaces the tooltips on this page. I'd like to get some more feedback about the tooltips before replacing them sitewide.