### PR TITLE
Ignore semver minor patches for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
   open-pull-requests-limit: 10
   versioning-strategy: increase-if-necessary
   ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
   - dependency-name: postcss
     versions:
     - 8.2.11


### PR DESCRIPTION
[Acc to the doc](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore), dependabot can be configured to ignore semver major, minor and patch version upgrades.

Let's start out with patch level upgrades and see how that goes. 