### PR TITLE
Detect react

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,5 +65,10 @@
     },
     "globals": {
         "require": false
-    }
+    },
+    "settings": {
+        "react": {
+          "version": "detect"
+        }
+      }
 }


### PR DESCRIPTION
* Builds have been failing because eslint thinks this is on react 18. This setting detects the version.